### PR TITLE
Correct password verification for revision 3 or greater

### DIFF
--- a/pyPdf/pdf.py
+++ b/pyPdf/pdf.py
@@ -936,15 +936,16 @@ class PdfFileReader(object):
         p_entry = encrypt['/P'].getObject()
         id_entry = self.trailer['/ID'].getObject()
         id1_entry = id_entry[0].getObject()
+        real_U = encrypt['/U'].getObject().original_bytes
         if rev == 2:
             U, key = _alg34(password, owner_entry, p_entry, id1_entry)
+            return U == real_U, key
         elif rev >= 3:
             U, key = _alg35(password, rev,
                     encrypt["/Length"].getObject() / 8, owner_entry,
                     p_entry, id1_entry,
                     encrypt.get("/EncryptMetadata", BooleanObject(False)).getObject())
-        real_U = encrypt['/U'].getObject().original_bytes
-        return U == real_U, key
+            return U[:16] == real_U[:16], key
 
     def getIsEncrypted(self):
         return self.trailer.has_key("/Encrypt")


### PR DESCRIPTION
According to spec, only the first 16 bytes must be compared when verifying password with Algorithm 3.5 revision 3 or greater.
