### PR TITLE
Py3: Correct use of string instead of bytes

### DIFF
--- a/pyPdf/generic.py
+++ b/pyPdf/generic.py
@@ -298,7 +298,7 @@ def readStringFromStream(stream):
             elif tok == b"r":
                 tok = b"\r"
             elif tok == b"t":
-                tok = "\t"
+                tok = b"\t"
             elif tok == b"b":
                 tok = b"\b"
             elif tok == b"f":

--- a/pyPdf/pdf.py
+++ b/pyPdf/pdf.py
@@ -903,15 +903,16 @@ class PdfFileReader(object):
         p_entry = encrypt['/P'].getObject()
         id_entry = self.trailer['/ID'].getObject()
         id1_entry = id_entry[0].getObject()
+        real_U = encrypt['/U'].getObject().original_bytes
         if rev == 2:
             U, key = _alg34(password, owner_entry, p_entry, id1_entry)
+            return U == real_U, key
         elif rev >= 3:
             U, key = _alg35(password, rev,
                     encrypt["/Length"].getObject() // 8, owner_entry,
                     p_entry, id1_entry,
                     encrypt.get("/EncryptMetadata", BooleanObject(False)).getObject())
-        real_U = encrypt['/U'].getObject().original_bytes
-        return U == real_U, key
+            return U[:16] == real_U[:16], key
 
     def getIsEncrypted(self):
         return "/Encrypt" in self.trailer


### PR DESCRIPTION
Fixes this traceback:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pyPdf/pdf.py", line 861, in decrypt
    return self._decrypt(password)
  File "pyPdf/pdf.py", line 866, in _decrypt
    encrypt = self.trailer['/Encrypt'].getObject()
  File "pyPdf/generic.py", line 476, in __getitem__
    return dict.__getitem__(self, key).getObject()
  File "pyPdf/generic.py", line 165, in getObject
    return self.pdf.getObject(self).getObject()
  File "pyPdf/pdf.py", line 616, in getObject
    retval = readObject(self.stream, self)
  File "pyPdf/generic.py", line 66, in readObject
    return DictionaryObject.readFromStream(stream, pdf)
  File "pyPdf/generic.py", line 527, in readFromStream
    value = readObject(stream, pdf)
  File "pyPdf/generic.py", line 51, in readObject
    return readStringFromStream(stream)
  File "pyPdf/generic.py", line 337, in readStringFromStream
    txt.extend(tok)
TypeError: an integer is required
```
