### PR TITLE
Trailing spaces and NUL characters in PDF cause failure identifying EOF

### DIFF
--- a/pyPdf/pdf.py
+++ b/pyPdf/pdf.py
@@ -701,9 +701,10 @@ class PdfFileReader(object):
         # start at the end:
         stream.seek(-1, 2)
         line = ''
-        while not [ch for ch in line if ch not in (' ','\x00')]:
-            line = self.readNextEndLine(stream)
-        if line[:5] != "%%EOF":
+        try:
+            while line[:5] != "%%EOF":
+                line = self.readNextEndLine(stream)
+        except IOError:
             raise utils.PdfReadError, "EOF marker not found"
 
         # find startxref entry - the location of the xref table

--- a/pyPdf/pdf.py
+++ b/pyPdf/pdf.py
@@ -701,7 +701,7 @@ class PdfFileReader(object):
         # start at the end:
         stream.seek(-1, 2)
         line = ''
-        while not line:
+        while not [ch for ch in line if ch not in (' ','\x00')]:
             line = self.readNextEndLine(stream)
         if line[:5] != "%%EOF":
             raise utils.PdfReadError, "EOF marker not found"


### PR DESCRIPTION
I have a collection of PDFs that contain a line of NUL and space characters on the line after the %%EOF marker. The current technique for identifying the %%EOF fails on these PDFs because the 'while not line' check on line 704 of pdf.py (the start of the read() method on PdfFileReader) isn't sufficient to identify this line of NUL and spaces as something worth ignoring.
