### PR TITLE
PDF never finishes writing

### DIFF
--- a/pyPdf/generic.py
+++ b/pyPdf/generic.py
@@ -414,7 +414,7 @@ class TextStringObject(unicode, PdfObject):
 
 
 class NameObject(str, PdfObject):
-    delimiterCharacters = "(", ")", "<", ">", "[", "]", "{", "}", "/", "%"
+    delimiterCharacters = "(", ")", "<", ">", "[", "]", "{", "}", "/", "%", ""
 
     def __init__(self, data):
         str.__init__(data)
@@ -687,7 +687,7 @@ class RectangleObject(ArrayObject):
 
     def getUpperLeft_x(self):
         return self.getLowerLeft_x()
-    
+
     def getUpperLeft_y(self):
         return self.getUpperRight_y()
 


### PR DESCRIPTION
Patch adds empty string to the NamedObject readFromStream deliminator list.

I have an example PDF that when writing the readFromStream would never return because no deliminator could be found, which caused it to keep pulling empty strings off the StringIO buffer.

I have no doubt that the update I've made is not the best solution, but it results in seemingly correct PDFs for me in this case.

I have the example PDF and could email it to you upon request.
