### PR TITLE
Accept xref streams with the type field not present.

### DIFF
--- a/pyPdf/pdf.py
+++ b/pyPdf/pdf.py
@@ -798,6 +798,11 @@ class PdfFileReader(object):
                             di = convertToInt(d, entrySizes[i])
                             if i == 0:
                                 xref_type = di
+                                # PDF spec: If the first element is zero, the
+                                # type field is not present, and it defaults
+                                # to type 1.
+                                if (0 == xref_type) and (0 == entrySizes[0]):
+                                    xref_type = 1
                             elif i == 1:
                                 if xref_type == 0:
                                     next_free_object = di


### PR DESCRIPTION
pyPdf can't parse a cross-reference stream unless the whole triple is given for its entries. But at least from PDF 1.6:

A value of zero for an element in the W array indicates that the corresponding field
is not present in the stream, and the default value is used, if there is one. If the first
element is zero, the type field is not present, and it defaults to type 1.
